### PR TITLE
use an actual table for the sponser table matrix

### DIFF
--- a/sponsor/index.md
+++ b/sponsor/index.md
@@ -15,7 +15,13 @@ The FOSS4G Boston 2017 Sponsorship Committee has worked hard to create a full va
 
 The Boston Team has worked diligently to structure our program so that there are standard packages at the Supporter, Bronze and Silver levels. We have also structured our higher tiers – Diamond, Platinum and Gold – to include  a variety of  à la carte benefits so that your investment in FOSS4G Boston 2017 best meets your specific objectives for the conference.
 
-![Sponsorship Tiers](sponsorship-tiers.png "Sponsorship Tiers")
-{: style="color:gray; font-size: 80%; text-align: center;"}
+| Level | Cost | Included registrations | Web-site promotion & signage | Booth | Co-located event| Named meal | Named social | T-shirt sleeve |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Diamond | $30,000 | 6 | X | 10x20 | X | X | X | X |
+| Platinum | $20,000 | 4 | X | 10x20 | X | X | X | |
+| Gold | $15,000 | 3 | X | 10x10 | X | X | |  |
+| Silver | $8,000 | 2 | X | 10x10 |  |  |  |  |
+| Bronze | $4,000 | 1 | X | 6' Tabletop |  |  |  |  |
+| Supporter | $2,000 | 1 | X | None |  |  |  |  |
 
 For more information please view our [prospectus document](SponsorshipProspectus.pdf)


### PR DESCRIPTION
in case people need to cut and paste, or are blind or on mobile